### PR TITLE
Add explicit bearerToken parameter to bulkImport

### DIFF
--- a/PlomerSwiftSdk/Classes/OpenAPIs/APIs/MonitoringProfileAPI+BulkImport.swift
+++ b/PlomerSwiftSdk/Classes/OpenAPIs/APIs/MonitoringProfileAPI+BulkImport.swift
@@ -18,8 +18,24 @@ extension MonitoringProfileAPI {
     /// which cannot send a `text/csv` request body — the generated Alamofire
     /// layer only encodes JSON / multipart / form bodies and traps on anything
     /// else. This method sends the raw CSV directly, reusing
-    /// `PlomerSwiftSdkAPI.basePath` and `PlomerSwiftSdkAPI.customHeaders` (where
-    /// the app configures its auth header), and decodes `BulkImportAccepted`.
+    /// `PlomerSwiftSdkAPI.basePath`, and decodes `BulkImportAccepted`.
+    ///
+    /// ## Authentication
+    ///
+    /// Because this method bypasses the `RequestBuilder` / Alamofire pipeline, it
+    /// is NOT touched by any auth interceptor the app installs via
+    /// `PlomerSwiftSdkAPI.requestBuilderFactory`. Pass the bearer token in
+    /// explicitly via `bearerToken` — the caller can read it fresh from its own
+    /// store (e.g. the Keychain) at call time, e.g.:
+    ///
+    /// ```swift
+    /// MonitoringProfileAPI.bulkImport(csv: csv, bearerToken: myAccessToken) { ... }
+    /// ```
+    ///
+    /// When `bearerToken` is provided it sets the `Authorization` header and takes
+    /// precedence over any `Authorization` in `PlomerSwiftSdkAPI.customHeaders`.
+    /// When it is `nil`, the method falls back to `PlomerSwiftSdkAPI.customHeaders`
+    /// for backward compatibility (which may be empty, yielding a 401).
     ///
     /// Poll `getBulkImportStatus(jobId:)` (generated, works as-is) for progress
     /// and results.
@@ -28,6 +44,8 @@ extension MonitoringProfileAPI {
     ///   - csv: CSV body, one URL per line. An optional `url` header line is
     ///     ignored. Blank lines are skipped and duplicates de-duplicated.
     ///     Maximum 500 rows.
+    ///   - bearerToken: bearer token to authenticate the request. When non-nil it
+    ///     is sent as `Authorization: Bearer <token>`, overriding `customHeaders`.
     ///   - urlSession: URLSession to use (defaults to `.shared`).
     ///   - apiResponseQueue: queue the completion handler is dispatched on.
     ///   - completion: `.success(BulkImportAccepted)` on HTTP 202, otherwise
@@ -37,6 +55,7 @@ extension MonitoringProfileAPI {
     @discardableResult
     public static func bulkImport(
         csv: String,
+        bearerToken: String? = nil,
         urlSession: URLSession = .shared,
         apiResponseQueue: DispatchQueue = PlomerSwiftSdkAPI.apiResponseQueue,
         completion: @escaping (Swift.Result<BulkImportAccepted, ErrorResponse>) -> Void
@@ -48,6 +67,9 @@ extension MonitoringProfileAPI {
         request.setValue("text/csv", forHTTPHeaderField: "Content-Type")
         for (header, value) in PlomerSwiftSdkAPI.customHeaders {
             request.setValue(value, forHTTPHeaderField: header)
+        }
+        if let bearerToken = bearerToken {
+            request.setValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
         }
         request.httpBody = csv.data(using: .utf8)
 


### PR DESCRIPTION
## Problem

`MonitoringProfileAPI.bulkImport(csv:)` doesn't authenticate correctly when the consuming app (plomer-ios) supplies bearer tokens via a token factory.

Root cause: `bulkImport` is a hand-written helper that **bypasses the `RequestBuilder` / Alamofire pipeline** (it builds a bare `URLRequest` on `URLSession` to send a raw `text/csv` body, which the generated Alamofire layer can't do). Because of that, it's never touched by the auth interceptor the app installs via `PlomerSwiftSdkAPI.requestBuilderFactory` (plomer-ios's `BearerTokenHandler`, which injects the Keychain token on every Alamofire request).

The only auth source `bulkImport` had was `PlomerSwiftSdkAPI.customHeaders`, which the app essentially never populates (it stores tokens in the Keychain, not `customHeaders` — that dict is only written transiently during a 401 refresh). So `bulkImport` requests typically went out with **no `Authorization` header → 401**.

## Change

Add an optional `bearerToken: String? = nil` parameter:

- When provided, sets `Authorization: Bearer <token>`, taking precedence over `customHeaders`.
- When `nil`, falls back to `customHeaders` — fully backward compatible (defaulted parameter; no existing call sites affected).

```swift
MonitoringProfileAPI.bulkImport(csv: csv, bearerToken: accessToken) { result in ... }
```

The doc comment now explains why the token must be passed explicitly (it's outside the interceptor pipeline).

## Notes

- This is self-contained and intentionally does **not** add automatic 401-refresh-and-retry (the interceptor's behavior for generated methods). A bulk import that hits a 401 surfaces as `.failure`; the caller refreshes + retries. A future change could route `bulkImport` through the interceptor for parity (the heavier "option 1").
- The edited file is listed in `.openapi-generator-ignore`, so this survives `openapi-generator generate`.

## Verification

`swift build` passes (only pre-existing unrelated warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)